### PR TITLE
Add -L to curl commands for redirects.

### DIFF
--- a/pages/cache/profiling-queries.mdx
+++ b/pages/cache/profiling-queries.mdx
@@ -75,8 +75,8 @@ ReadySet metrics are formatted for easy integration with [Prometheus](https://pr
 1. Download the metrics utility and its `requirements.txt`:
 
 ```sql 
-curl -O "https://readyset.io/quickstart/metrics.py"
-curl -O "https://readyset.io/quickstart/requirements.txt"
+curl -L -O "https://readyset.io/quickstart/metrics.py"
+curl -L -O "https://readyset.io/quickstart/requirements.txt"
 ```
 
 2. Install dependencies for the utility:

--- a/pages/demos/caching-slow-queries-imdb.mdx
+++ b/pages/demos/caching-slow-queries-imdb.mdx
@@ -17,7 +17,7 @@ import Image from 'next/image'
 First, download the IMDB dataset for MySQL:
 
 ```
-curl -O "https://readyset.io/quickstart/imdb-mysql.sql"
+curl -L -O "https://readyset.io/quickstart/imdb-mysql.sql"
 ```
 
 Then, connect to your ReadySet instance and import the dataset:
@@ -36,7 +36,7 @@ mysql -h127.0.0.1 -uroot -P3307 testdb -preadyset <  imdb-mysql.sql
 First, download the IMDB dataset for Postgres:
 
 ```
-curl -O "https://readyset.io/quickstart/imdb-postgres.sql"
+curl -L -O "https://readyset.io/quickstart/imdb-postgres.sql"
 ```
 
 Then, connect to your ReadySet instance and import the dataset:

--- a/pages/deploy/deploy-with-docker.mdx
+++ b/pages/deploy/deploy-with-docker.mdx
@@ -69,7 +69,7 @@ At this point, ReadySet is ready to start caching queries.
 **1. Download the ReadySet Docker compose file**
 
 ```sh
-curl -o compose.yml "https://readyset.io/quickstart/compose.yml"
+curl -L -o compose.yml "https://readyset.io/quickstart/compose.yml"
 ```
 
 **2. Provide your connection string**


### PR DESCRIPTION
Now that we shorten the urls for artifacts, we need to pass -L to curl so it properly follows the redirects.