### PR TITLE
Update CLI docs

### DIFF
--- a/pages/reference/cli/readyset-server.mdx
+++ b/pages/reference/cli/readyset-server.mdx
@@ -37,22 +37,10 @@ The IP address/hostname and port that the ReadySet Server listens on.
 **Env variable:** `LISTEN_ADDRESS`
 </div>
 
-#### `--authority`
-
-<div class="option-details" markdown="1">
-The external authority for a distributed ReadySet deployment. The authority handles node discovery, leader election, and consensus and manages internal state and metrics.
-
-**Possible values:** `"consul"`
-
-**Default:** `"consul"`
-
-**Env variable:** `AUTHORITY`
-</div>
-
 #### `--authority-address`
 
 <div class="option-details" markdown="1">
-The IP address/hostname and port of the external authority.
+The IP address/hostname and port of the external authority. ReadySet supports Consul as the external authority.
 
 **Env variable:** `AUTHORITY_ADDRESS`
 </div>
@@ -89,42 +77,6 @@ Don't sent anonymous [telemetry data](../telemetry.md) to ReadySet.
 **Env variable:** `DISABLE_TELEMETRY`
 </div>
 
-#### `--disable-upstream-ssl-verification`
-
-<div class="option-details" markdown="1">
-Disable verification of SSL certificates supplied by the upstream database on connections to replicate data and proxy queries (Postgres only, ignored for MySQL).
-
-**Env variable:** `DISABLE_UPSTREAM_SSL_VERIFICATION`
-
-<Callout tpye="warning">If invalid certificates are trusted, any certificate for any site will be trusted. Use this option with caution.</Callout>
-</div>
-
-#### `--durability`
-
-<div class="option-details" markdown="1">
-The durability of the tables that ReadySet replicates from the upstream database as the basis for caching query results.  
-
-**Possible values:**
-
-- `"persistent"`: Store replicated tables on disk (at the location specified by [`--db-dir`](#--db-dir)). Do not delete the data when the ReadySet Server is stopped. Suitable for production deployments.
-- `"ephemeral"`: Store replicated tables on disk (at the location specified by [`--db-dir`](#--db-dir)). Delete the data when the ReadySet Server is stopped. Suitable for testing only.
-- `"memory"`: Store replicated tables entirely in memory. Suitable for testing only.
-
-**Default:** `"persistent"`
-</div>
-
-#### `--eviction-policy`
-
-<div class="option-details" markdown="1">
-When possible, ReadySet stores only certain results sets for a query in memory. For example, if a query is [parameterized](/features/supported-sql-syntax#parameters) on user IDs, ReadySet would only cache the results of that query for the active subset of users, since they are the ones issuing requests. This is referred to as "partial materialization".
-
-The `--eviction-policy` option determines the strategy for evicting cache entries from partial materializations once the overall memory limit (see [`--memory-limit`](#-memory-limit-m)) has been surpassed.
-
-**Possible values:** `"random"`, `"lru"`, `"generational"`
-
-**Default:** `"random"`
-</div>
-
 #### `--external-address`
 
 <div class="option-details" markdown="1">
@@ -141,16 +93,6 @@ The IP address/hostname to advertise to ReadySet instances running in the same d
 The port to advertise to ReadySet instances running in the same deployment. This also defines the port of the Prometheus endpoint for [ReadySet metrics](http://docs/rustdoc/readyset_client/metrics/recorded/index.html).
 
 **Default**: `6033`
-</div>
-
-#### `--allow-full-materialization`
-
-<div class="option-details" markdown="1">
-ReadySet must sometimes store the entire result set for a query in memory, for example, when there is no `WHERE` filter or when the `WHERE` filter is not [parameterized](/features/supported-sql-syntax#parameters) (by the user or by ReadySet). This is referred to as "full materialization".
-
-By default, ReadySet does not allow caching queries that need full materialization. The `--allow-full-materialization` option allows ReadySet to cache queries that would be fully materialized, but should only be used if there is certainty that the full materialization will be able to fit in the available memory of the system.
-
-**Env variable:** `ALLOW_FULL_MATERIALIZATION`
 </div>
 
 #### `--help`, `-h`
@@ -208,30 +150,6 @@ Once memory usage surpasses this limit, ReadySet starts evicting cache entries f
 <Callout>For production deployments, start by setting this to 60-80% of the machine's total memory. Then run the system under load, observe, and increase or decrease as needed.</Callout>
 </div>
 
-#### `--memory-check-every`
-
-<div class="option-details" markdown="1">
-The frequency, in seconds, at which to check memory usage by ReadySet. Once usage surpasses the limit set in [`--memory-limit`](#-memory-limit-m), ReadySet starts evicting cache entries for partial materializations based on the [`--eviction-policy`](#-eviction-policy).
-
-**Default:** `1`
-
-**Env variable:** `MEMORY_CHECK_EVERY`
-</div>
-
-#### `--no-readers`
-
-<div class="option-details" markdown="1">
-Do not run reader nodes on this instance. Reader nodes are the part of the dataflow graph that serve cached results for a query.
-</div>
-
-#### `--persistence-threads`
-
-<div class="option-details" markdown="1">
-Number of background threads used by RocksDB, the storage engine for ReadySet's snapshot of upstream database tables.
-
-**Default:** `6`
-</div>
-
 #### `--prometheus-metrics`
 
 <div class="option-details" markdown="1">
@@ -250,22 +168,6 @@ For a distributed ReadySet deployment with multiple ReadySet Server instances, t
 **Env variable:** `NORIA_QUORUM`
 </div>
 
-#### `--reader-only`
-
-<div class="option-details" markdown="1">
-Run only reader nodes on this instance. Reader nodes are the part of the dataflow graph that serve cached results for a query.
-</div>
-
-#### `--replication-pool-size`
-
-<div class="option-details" markdown="1">
-The number of connections to the upstream database for snapshotting and replication.
-
-**Default:** `50`
-
-<Callout type="warning">This can be set as high as the number of tables you want ReadySet to snapshot/replicate. However, more connections will increase both the load on your upstream database and memory usage by ReadySet.</Callout>
-</div>
-
 #### `--replication-tables`
 
 <div class="option-details" markdown="1">
@@ -274,14 +176,6 @@ By default, ReadySet attempts to snapshot and replicate all tables in the databa
 This option accepts a comma-separated list of `<schema>.<table>` (specific table in a schema) or `<schema>.*` (all tables in a schema) for Postgres and `<database>.<table>` for MySQL.  
 
 **Env variable:** `REPLICATION_TABLES`
-</div>
-
-#### `--snapshot-report-interval-secs`
-
-<div class="option-details" markdown="1">
-The time, in seconds, between logging the [snapshotting progress](/cache/check-snapshotting) and estimated time remaining for each table.
-
-**Default:** `30`
 </div>
 
 #### `--ssl-root-cert`
@@ -358,12 +252,10 @@ These examples focus on a distributed ReadySet deployment (i.e., ReadySet Server
 <Tab>
         ``` shell
         readyset-server \
-        --deployment="<deployment name>" \
         --upstream-db-url="postgresql://<db user>:<db password>@<db address>:5432/<database>" \
-        --query-caching="<caching mode>" \
         --username=<readyset user> \
         --password=<readyset password> \
-        --address=<readyset server address> \
+        --address=<readyset adapter address> \
         --authority-address=<consul address> \
         >> logs/readyset.log 2>&1 &
         ```
@@ -371,9 +263,7 @@ These examples focus on a distributed ReadySet deployment (i.e., ReadySet Server
 <Tab>
         ``` shell
         readyset-server \
-        --deployment="<deployment name>" \
         --upstream-db-url="mysql://<db user>:<db password>@<db address>:3306/<database>" \
-        --query-caching="<caching mode>" \
         --username=<readyset user> \
         --password=<readyset password> \
         --address=<readyset server address> \
@@ -382,14 +272,13 @@ These examples focus on a distributed ReadySet deployment (i.e., ReadySet Server
         ```
 </Tab>
 </Tabs>
-1. Start one of more ReadySet Adapters:
+1. Start one or more ReadySet Adapters:
 <Tabs items={['Postgres', 'MySQL']}>
 <Tab>
 
         ``` shell
         readyset \
-        --deployment="<deployment name>" \
-        --database-type=postgresql \
+        --upstream-db-url="mysql://<db user>:<db password>@<db address>:3306/<database>" \
         --username=<readyset user> \
         --password=<readyset password> \
         --address=<readyset adapter address> \
@@ -401,8 +290,7 @@ These examples focus on a distributed ReadySet deployment (i.e., ReadySet Server
 
         ``` shell
         readyset-server \
-        --deployment="<deployment name>" \
-        --database-type=mysql \
+        --upstream-db-url="mysql://<db user>:<db password>@<db address>:3306/<database>" \
         --username=<readyset user> \
         --password=<readyset password> \
         --address=<readyset server address> \

--- a/pages/reference/cli/readyset.mdx
+++ b/pages/reference/cli/readyset.mdx
@@ -33,49 +33,19 @@ readyset --help
 <div class="option-details" markdown="1">
 The IP address/hostname and port that ReadySet listens on.
 
+**Default:** 3307 for MySQL deployments and 5433 for PostgreSQL deployments.
+
 **Env variable:** `LISTEN_ADDRESS`
-</div>
-
-#### `--allow-unauthenticated-connections`
-
-<div class="option-details" markdown="1">
-Don't require authentication for any client connections. When passed, `--username` and `--password` are ignored.
-
-**Env variable:** `ALLOW_UNAUTHENTICATED_CONNECTIONS`
-</div>
-
-#### `--authority`
-
-<div class="option-details" markdown="1">
-The external authority for a distributed ReadySet deployment. The authority handles node discovery, leader election, and consensus and manages internal state and metrics.
-
-This option is ignored when `--standalone` is passed. In that case, the ReadySet Server and Adapter are run as a single process, and no external authority is required.
-
-**Possible values:** `"consul"`
-
-**Default:** `"consul"`
-
-**Env variable:** `AUTHORITY`
 </div>
 
 #### `--authority-address`
 
 <div class="option-details" markdown="1">
-The IP address/hostname and port of the external authority.
+The IP address/hostname and port of the external authority. ReadySet clusters support Consul as the external authority.
 
 This option is ignored when `--standalone` is passed. In that case, the ReadySet Server and Adapter are run as a single process, and no external authority is required.
 
 **Env variable:** `AUTHORITY_ADDRESS`
-</div>
-
-#### `--database-type`
-
-<div class="option-details" markdown="1">
-The database engine that ReadySet is integrating with.
-
-**Possible values:** `"postgresql"`, `"mysql"`
-
-**Env variable:** `DATABASE_TYPE`
 </div>
 
 #### `--db-dir`
@@ -93,6 +63,8 @@ The path to the directory where ReadySet stores replicated table data.
 <div class="option-details" markdown="1">
 A unique identifier for the ReadySet deployment.
 
+**Default:** tmp-readyset
+
 **Env variable:** `DEPLOYMENT`
 </div>
 
@@ -104,29 +76,6 @@ Don't sent anonymous [telemetry data](../telemetry.md) to ReadySet.
 **Env variable:** `DISABLE_TELEMETRY`
 </div>
 
-#### `--disable-upstream-ssl-verification`
-
-<div class="option-details" markdown="1">
-Disable verification of SSL certificates supplied by the upstream database on connections to replicate data and proxy queries (Postgres only, ignored for MySQL).
-
-**Env variable:** `DISABLE_UPSTREAM_SSL_VERIFICATION`
-<Callout type="warning"> If invalid certificates are trusted, any certificate for any site will be trusted. Use this option with caution.</Callout>
-</div>
-
-#### `--durability`
-
-<div class="option-details" markdown="1">
-The durability of the tables that ReadySet replicates from the upstream database as the basis for caching query results.  
-
-**Possible values:**
-
-- `"persistent"`: Store replicated tables on disk (at the location specified by [`--db-dir`](#--db-dir)). Do not delete the data when the ReadySet Server is stopped. Suitable for production deployments.
-- `"ephemeral"`: Store replicated tables on disk (at the location specified by [`--db-dir`](#--db-dir)). Delete the data when the ReadySet Server is stopped. Suitable for testing only.
-- `"memory"`: Store replicated tables entirely in memory. Suitable for testing only.
-
-**Default:** `"persistent"`
-</div>
-
 #### `--embedded-readers`
 
 <div class="option-details" markdown="1">
@@ -135,28 +84,6 @@ For a distributed ReadySet deployment, store cached query results with the Adapt
 To use this option, you must pass `--no-readers` and `--reader-replicas` when starting [`readyset-server`](readyset-server.md).
 
 **Env variable:** `EMBEDDED_READERS`
-</div>
-
-#### `--eviction-policy`
-
-<div class="option-details" markdown="1">
-When possible, ReadySet stores only certain results sets for a query in memory. For example, if a query is [parameterized](/features/supported-sql-syntax#parameters) on user IDs, ReadySet would only cache the results of that query for the active subset of users, since they are the ones issuing requests. This is referred to as "partial materialization".
-
-The `--eviction-policy` option determines the strategy for evicting cache entries from partial materializations once the overall memory limit (see [`--memory-limit`](#-memory-limit-m)) has been surpassed.
-
-**Possible values:** `"random"`, `"lru"`, `"generational"`
-
-**Default:** `"random"`
-</div>
-
-#### `--allow-full-materialization`
-
-<div class="option-details" markdown="1">
-ReadySet must sometimes store the entire result set for a query in memory, for example, when there is no `WHERE` filter or when the `WHERE` filter is not [parameterized](/features/supported-sql-syntax#parameters) (by the user or by ReadySet). This is referred to as "full materialization".
-
-By default, ReadySet does not allow caching queries that need full materialization. The `--allow-full-materialization` option allows ReadySet to cache queries that would be fully materialized, but should only be used if there is certainty that the full materialization will be able to fit in the available memory of the system.
-
-**Env variable:** `ALLOW_FULL_MATERIALIZATION`
 </div>
 
 #### `--help`, `-h`
@@ -213,16 +140,6 @@ Once memory usage surpasses this limit, ReadySet starts evicting cache entries f
 <Callout>For production deployments, start by setting this to 60-80% of the machine's total memory. Then run the system under load, observe, and increase or decrease as needed.</Callout>
 </div>
 
-#### `--memory-check-every`
-
-<div class="option-details" markdown="1">
-The frequency, in seconds, at which to check memory usage by ReadySet. Once usage surpasses the limit set in [`--memory-limit`](#-memory-limit-m), ReadySet starts evicting cache entries for partial materializations based on the [`--eviction-policy`](#-eviction-policy).
-
-**Default:** `1`
-
-**Env variable:** `MEMORY_CHECK_EVERY`
-</div>
-
 #### `--metrics-address`
 
 <div class="option-details" markdown="1">
@@ -233,28 +150,6 @@ This option is ignored unless [`--prometheus-metrics`](#--prometheus-metrics) is
 **Default:** `0.0.0.0:6034`
 
 **Env variable:** `METRICS_ADDRESS`
-</div>
-
-#### `--migration-task-interval`
-
-<div class="option-details" markdown="1">
-When [`--query-caching`](#--query-caching) is set to `"explicit"`, the frequency, in milliseconds, at which to check whether queries that ReadySet has proxied to the upstream database are [supported by ReadySet](/features/supported-sql-syntax#query-caching).
-
-After this check is run on a query, [`SHOW PROXIED QUERIES`](/cache/creating-a-cache#checking-query-support) returns either `yes` or `no` for `readyset supported`. Before this check is run on a query, or when this check fails for a query (e.g., because it references tables that have not finished snapshotting), `SHOW PROXIED QUERIES` returns `pending` for `readyset supported`.
-
-**Default:** `20000`
-
-**Env variable:** `MIGRATION_TASK_INTERVAL`
-</div>
-
-#### `--non-blocking-reads`
-
-<div class="option-details" markdown="1">
-When ReadySet cannot return results for a cached query (i.e., a cache miss), proxy the query to the upstream database while ReadySet fills the cache. If this option is not passed, ReadySet will not return results until the cache is ready.
-
-**Env variable:** `NON_BLOCKING_READS`
-
-<Callout type="info">This option improves performance for cache misses but at the cost of increasing the load on the upstream database.</Callout>
 </div>
 
 #### `--password`
@@ -269,14 +164,6 @@ This option is ignored when [`--allow-unauthenticated-connections`](#--allow-una
 **Env variable:** `ALLOWED_PASSWORD`
 </div>
 
-#### `--persistence-threads`
-
-<div class="option-details" markdown="1">
-Number of background threads used by RocksDB, the storage engine for ReadySet's snapshot of upstream database tables.
-
-**Default:** `6`
-</div>
-
 #### `--prometheus-metrics`
 
 <div class="option-details" markdown="1">
@@ -285,28 +172,10 @@ Output ReadySet metrics to the Prometheus endpoint at `<metrics address>/metrics
 **Env variable:** `PROMETHEUS_METRICS`
 </div>
 
-#### `--query-caching`
-
-<div class="option-details" markdown="1">
-The query caching mode for ReadySet.
-
-**Possible values:**
-
-- `"explicit"`: ReadySet does not automatically cache queries. Instead, users use the [`CREATE CACHE`](/cache/creating-a-cache) command to cache queries.
-- "`inrequestpath`: ReadySet caches [supported queries](/features/queries) automatically but blocks queries from returning results until the cache is ready.
-- "`async`": ReadySet caches [supported queries](/features/queries) automatically but proxies queries to the upstream database until the cache is ready.
-
-**Default:** `"async"`
-
-**Env variable:** `QUERY_CACHING`
-
-<Callout>For most deployments, `explicit` mode is recommended, as it gives you the most flexibility and control.</Callout>
-</div>
-
 #### `--query-log`
 
 <div class="option-details" markdown="1">
-Include query-specific execution details in Prometheus metrics.
+Include query-specific execution details in Prometheus metrics. Enabled by default if PROMETHEUS_METRICS is set.
 
 To use this option, you must pass [`--prometheus-metrics](#--prometheus-metrics) as well.
 
@@ -316,31 +185,11 @@ To use this option, you must pass [`--prometheus-metrics](#--prometheus-metrics)
 #### `--query-log-ad-hoc`
 
 <div class="option-details" markdown="1">
-Include execution details for ad-hoc queries in Prometheus metrics. Ad-hoc queries are those that do not use [parameters](/features/supported-sql-syntax#parameters).
+Include execution details for ad-hoc queries in Prometheus metrics. Ad-hoc queries are those that do not use [parameters](/features/supported-sql-syntax#parameters). Enabled by default if PROMETHEUS_METRICS is set.
 
 To use this option, you must pass [`--query-log](#--query-log) as well.
 
 **Env variable:** `QUERY_LOG_AD_HOC`
-</div>
-
-#### `--quorum`, `-q`
-
-<div class="option-details" markdown="1">
-For a distributed ReadySet deployment with multiple ReadySet Server instances, the number of ReadySet Server instances. ReadySet will wait until this number is reached before accepting requests.
-
-**Default:** `1`
-
-**Env variable:** `NORIA_QUORUM`
-</div>
-
-#### `--replication-pool-size`
-
-<div class="option-details" markdown="1">
-The number of connections to the upstream database for snapshotting and replication.
-
-**Default:** `50`
-
-<Callout type="warning">This can be set as high as the number of tables you want ReadySet to snapshot/replicate. However, more connections will increase both the load on your upstream database and memory usage by ReadySet.</Callout>
 </div>
 
 #### `--replication-tables`
@@ -351,14 +200,6 @@ By default, ReadySet attempts to snapshot and replicate all tables in the databa
 This option accepts a comma-separated list of `<schema>.<table>` (specific table in a schema) or `<schema>.*` (all tables in a schema) for Postgres and `<database>.<table>` for MySQL.  
 
 **Env variable:** `REPLICATION_TABLES`
-</div>
-
-#### `--snapshot-report-interval-secs`
-
-<div class="option-details" markdown="1">
-The time, in seconds, between logging the [snapshotting progress](/cache/check-snapshotting) and estimated time remaining for each table.
-
-**Default:** `30`
 </div>
 
 #### `--ssl-root-cert`
@@ -401,21 +242,6 @@ To use this option, you must set [`--tracing-host`](#--tracing-host).
 **Env variable:** `TRACING_SAMPLE_PERCENT`
 </div>
 
-#### `--unsupported-set-mode`
-
-<div class="option-details" markdown="1">
-How ReadySet behaves when receiving unsupported `SET` statements.
-
-**Possible values:**
-
--  `"error"`: Return an error to the client.
-- `"proxy"`: Proxy all subsequent statements to the upstream database.
-
-**Default:** `"error"`
-
-**Env variable:** `UNSUPPORTED_SET_MODE`
-</div>
-
 #### `--upstream-db-url`
 
 <div class="option-details" markdown="1">
@@ -446,18 +272,6 @@ Print ReadySet version information. See the [example](#print-version-information
 <Callout>You can also use the custom `SHOW READYSET VERSION` SQL command to print ReadySet version information.</Callout>
 </div>
 
-#### `--views-polling-interval`
-
-<div class="option-details" markdown="1">
-For a distributed ReadySet deployment with multiple ReadySet Adapters, each Adapter needs to know about the caches on the ReadySet Server. This flag sets the interval, in seconds, at which to poll the ReadySet Server.
-
-This option is not relevant when using [`--embedded-readers`](#--embedded-readers).
-
-**Default:** `300`
-
-**Env variable:** `OUTPUTS_POLLING_INTERVAL`
-</div>
-
 ## Examples
 
 These examples focus on running a standard ReadySet deployment (i.e., ReadySet Server and Adapter running as a single process on a single machine). For running a distributed ReadySet deployment, see the [`readyset-server` examples](readyset-server.md#examples).
@@ -468,13 +282,11 @@ These examples focus on running a standard ReadySet deployment (i.e., ReadySet S
     ``` shell
     readyset \
     --standalone \
-    --deployment="<deployment name>" \
     --upstream-db-url="postgresql://<db user>:<db password>@<db address>:5432/<database>" \
     --database-type=postgresql \
     --query-caching="<caching mode>" \
     --username=<readyset user> \
     --password=<readyset password> \
-    --address=<readyset address> \
     >> logs/readyset.log 2>&1 &
     ```
 </Tab>
@@ -482,13 +294,11 @@ These examples focus on running a standard ReadySet deployment (i.e., ReadySet S
     ``` shell
     readyset \
     --standalone \
-    --deployment="<deployment name>" \
     --upstream-db-url="mysql://<db user>:<db password>@<db address>:3306/<database>" \
     --database-type=mysql \
     --query-caching="<caching mode>" \
     --username=<readyset user> \
     --password=<readyset password> \
-    --address=<readyset address> \
     >> logs/readyset.log 2>&1 &
     ```
 </Tab>
@@ -502,17 +312,11 @@ To output ReadySet metrics to Prometheus, pass `--metrics-address` and `--promet
     ``` shell
     readyset \
     --standalone \
-    --deployment="<deployment name>" \
     --upstream-db-url="postgresql://<db user>:<db password>@<db address>:5432/<database>" \
-    --database-type=postgresql \
-    --query-caching="<caching mode>" \
     --username=<readyset user> \
     --password=<readyset password> \
-    --address=<readyset address> \
     --prometheus-metrics \
     --metrics-address=<prometheus address> \
-    --query-log \
-    --query-log-ad-hoc \
     >> logs/readyset.log 2>&1 &
     ```
 </Tab>
@@ -521,17 +325,11 @@ To output ReadySet metrics to Prometheus, pass `--metrics-address` and `--promet
     ``` shell
     readyset \
     --standalone \
-    --deployment="<deployment name>" \
     --upstream-db-url="mysql://<db user>:<db password>@<db address>:3306/<database>" \
-    --database-type=mysql \
-    --query-caching="<caching mode>" \
     --username=<readyset user> \
     --password=<readyset password> \
-    --address=<readyset address> \
     --prometheus-metrics \
     --metrics-address=<prometheus address> \
-    --query-log \
-    --query-log-ad-hoc \
     >> logs/readyset.log 2>&1 &
     ```
 </Tab>


### PR DESCRIPTION
Hides several CLI arguments that ReadySet does not want to consider supported at the moment. These arguments exist in the code, but will not show up if the user runs `--help`.