### PR TITLE
Fix wording for 'CREATE CACHE ALWAYS'

### DIFF
--- a/pages/cache/creating-a-cache.mdx
+++ b/pages/cache/creating-a-cache.mdx
@@ -32,7 +32,7 @@ CREATE CACHE [ALWAYS] [<name>] FROM <query>;
 ```
 - `<name>` is optional. If a cache is not named, ReadySet automatically assigns an identifier.
 - `<query>` is the full text of the query or the unique identifier assigned to the query by ReadySet, as seen in output of `SHOW PROXIED QUERIES`.
-- `ALWAYS` is optional. If the `CREATE CACHE` command is executed inside a transaction (e.g., due to an ORM), use `ALWAYS` to run the command against ReadySet; otherwise, the command will be proxied to the upstream database with the rest of the transaction.
+- `ALWAYS` is optional. If a cached query is executed inside a transaction (e.g., due to an ORM), use `ALWAYS` to run the query against ReadySet; otherwise, the query will be proxied to the upstream database with the rest of the transaction.
 ​
 ## View cached queries
 To show all queries that have been cached, use:


### PR DESCRIPTION
The things that get executed against readyset with `ALWAYS` are queries, not `CREATE CACHE` commands themselves.