### PR TITLE
updated documentation to not rely on docker compose

### DIFF
--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -19,7 +19,7 @@ Setting up your application to take advantage of ReadySet takes a few steps.
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 
 traffic ongoing while still taking advantage of ReadySet's caching for read-heavy workloads.
 
-This will take 3 steps. You’ll need to add ReadySet as a read replica and configure ActiveRecord to 
+This will take three steps. You’ll need to add ReadySet as a read replica and configure ActiveRecord to 
 route traffic and finally configure Rails' connection switching middleware with a few quick changes.
 
 ### a. Update database configuration

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -2,30 +2,30 @@ import { Tabs, Tab } from 'nextra/components'
 import { Callout } from 'nextra/components'
 import Image from 'next/image'
 
-# Using ReadySet with Ruby on Rails
+# Use ReadySet with Ruby on Rails
 
 Enabling ReadySet to work with a Rails application requires Rails multiple database support, which is easy to configure. 
 In short, ReadySet becomes a lighting fast read-replica. This guide walks you through how to configure ReadySet 
 in your Rails app. 
 
-## 0. Setting up ReadySet
+## 0. Set up ReadySet
 Setting up your application to take advantage of ReadySet takes a few steps. 
   1. [Make sure your database is configured for ReadySet](/get-started/configure-your-database)
   2. [Install ReadySet](/get-started/install-rs)
 
-## 1. Configuring Rails in three steps
+## 1. Configure Rails in three steps
 
 [Ruby On Rails allows you to configure ReadySet](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 
 traffic ongoing while still taking advantage of ReadySet's caching for read-heavy workloads.
 
-This will take three steps. You’ll need to add ReadySet as a read replica and configure ActiveRecord to 
+This will take three steps. You'll need to add ReadySet as a read replica and configure ActiveRecord to 
 route traffic and finally configure Rails' connection switching middleware with a few quick changes.
 
 ### a. Update database configuration
 
 Taking advantage of ReadySet means defining a read replica of your primary database. 
-Rails makes this incredibly simple and in the case of ReadySet, <b>you’ll configure the replica to point 
+Rails makes this incredibly simple and in the case of ReadySet, <b>you'll configure the replica to point 
 to your ReadySet instance</b>. We recommend following Rails established patterns and name your primary 
 database as `primary` and then your read replica ReadySet instance as `primary_replica`. 
 
@@ -49,14 +49,14 @@ production:
     database_tasks: false
 ```
 
-It’s important to note that the `primary_replica` definition points to ReadySet and that two 
+It's important to note that the `primary_replica` definition points to ReadySet and that two 
 flags are set: `replica` is `true` and `database_tasks` is `false`. The `database_tasks` flag 
-will disable Rails database migrations running against ReadySet. This isn’t needed as 
+will disable Rails database migrations running against ReadySet. This isn't needed as 
 ReadySet will see any changes to the primary database already. 
 
 ### b. Update `ApplicationRecord` to use two connections
 
-In your application's `app/models` directory, you’ll find a base class for all of your model classes 
+In your application's `app/models` directory, you'll find a base class for all of your model classes 
 often called `ApplicationRecord`. Open up that class and add the following line: 
 
 ```ruby
@@ -82,7 +82,7 @@ What's more, if for some reason you do not have access to an `ApplicationRecord`
 
 ### c. Activate connection switching middleware
 
-Finally, you’ll need to activate Rails middleware that’ll ensure writes go to the primary database and 
+Finally, you'll need to activate Rails middleware that'll ensure writes go to the primary database and 
 reads through ReadySet. First run this command to generate a configuration file: 
 
 ```sh
@@ -100,11 +100,11 @@ Rails.application.configure do
 end
 ```
 
-It’s important to note that a delay of 2 seconds is designed to ensure the read replica (in this case ReadySet) 
+It's important to note that a delay of 2 seconds is designed to ensure the read replica (in this case ReadySet) 
 is consistent with writes that are going directly to the primary database. 
 
-## You’re off to the races! 
+## You're off to the races! 
 
 At this point, if you start your Rails application, read requests will go directly to ReadySet and 
-writes will go to your primary Postgres database. You’ll next need to configure which SQL select statements (i.e. reads) you’ll 
+writes will go to your primary Postgres database. You'll next need to configure which SQL select statements (i.e. reads) you’ll 
 want to cache. Check out [our caching guide](/get-started/cache/creating-a-cache) for more information. 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -4,9 +4,9 @@ import Image from 'next/image'
 
 # Use ReadySet with Ruby on Rails
 
-Enabling ReadySet to work with a Rails application requires Rails multiple database support, which is easy to configure. 
-In short, ReadySet becomes a lighting fast read-replica. This guide walks you through how to configure ReadySet 
-in your Rails app. 
+This guide walks you through how to use ReadySet with your Ruby on Rails app. 
+To do this, you'll use the [built-in Rails multiple database support]((https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching)) to get the performance of 
+caching with the simplicity of a single read replica. 
 
 ## 0. Set up ReadySet
 Setting up your application to take advantage of ReadySet takes a few steps. 
@@ -15,12 +15,12 @@ Setting up your application to take advantage of ReadySet takes a few steps.
 
 ## 1. Configure Rails in three steps
 
-[Ruby On Rails allows you to configure ReadySet](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
+Ruby On Rails allows you to configure ReadySet as a read replica and define a time window after writes 
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 
 traffic ongoing while still taking advantage of ReadySet's caching for read-heavy workloads.
 
-This will take three steps. You'll need to add ReadySet as a read replica and configure ActiveRecord to 
-route traffic and finally configure Rails' connection switching middleware with a few quick changes.
+This will take three steps. You'll need to add ReadySet as a read replica, then configure ActiveRecord to 
+route traffic, and finally configure Rails' connection switching middleware with a few quick changes.
 
 ### a. Update database configuration
 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -13,7 +13,7 @@ Setting up your application to take advantage of ReadySet takes a few steps.
   1. [Make sure your database is configured for ReadySet](/get-started/configure-your-database)
   2. [Install ReadySet](/get-started/install-rs)
 
-## 1. Configuring Rails in 3 steps
+## 1. Configuring Rails in three steps
 
 [Ruby On Rails allows you to configure ReadySet](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -9,7 +9,7 @@ To do this, you'll use the [built-in Rails multiple database support]((https://g
 caching with the simplicity of a single read replica. 
 
 ## 0. Set up ReadySet
-Setting up your application to take advantage of ReadySet takes a few steps. 
+First, you'll set up ReadySet using Docker.
   1. [Make sure your database is configured for ReadySet](/get-started/configure-your-database)
   2. [Install ReadySet](/get-started/install-rs)
 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -5,37 +5,24 @@ import Image from 'next/image'
 # Using ReadySet with Ruby on Rails
 
 Enabling ReadySet to work with a Rails application requires Rails multiple database support, which is easy to configure. 
-In short, ReadySet becomes a lighting fast read-replica. 
+In short, ReadySet becomes a lighting fast read-replica. This guide walks you through how to configure ReadySet 
+in your Rails app. 
 
-## Setting up ReadySet
-ReadySet can speed up Rails read queries quite easily. Setting up your application to take advantage of ReadySet takes a few steps. 
-First, connect ReadySet to your database. For instance, if [running with Docker](/get-started/install-rs) and connecting to Postgres, ensure the 
-`UPSTREAM_DB_URL` environment variable is pointing to your Postgres instance. For instance, use the standard Postgres connection 
-string in the format `postgresql://user:password@hostl:5432/database_name`. 
+## 0. Setting up ReadySet
+Setting up your application to take advantage of ReadySet takes a few steps. 
+  1. [Make sure your database is configured for ReadySet](/get-started/configure-your-database)
+  2. [Install ReadySet](/get-started/install-rs)
 
-Next, take note of the host address for your ReadySet instance. This will be important because this will become the address of the 
-read replica you'll add to your Rails application. By default, ReadySet listens on port 5433. 
+## 1. Configuring Rails in 3 steps
 
-To ensure [ReadySet is properly configured](/get-started/cache/check-snapshotting) and pointing to your target database, simply use 
-the Postgres client, `psql` and connect to ReadySet as you would a normal Postgres instance. You can do so by using the normal Postgres 
-connection string and substitute in the port ReadySet is listening on (i.e. 5433). 
-
-```sh
-psql postgresql://user:password@host:5433/database_name
-```
-
-Once you’re in the Postgres console, type `show readyset status;` and look for Snapshot Status to be Completed. 
-
-## Configuring Rails in 3 steps
-
-[Ruby On Rails allows you to configure ReadySet](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
+[Ruby On Rails allows you to configure ReadySet(https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 
 traffic ongoing while still taking advantage of ReadySet's caching for read-heavy workloads.
 
 This will take 3 steps. You’ll need to add ReadySet as a read replica and configure ActiveRecord to 
 route traffic and finally configure Rails' connection switching middleware with a few quick changes.
 
-### Update database configuration
+### a. Update database configuration
 
 Taking advantage of ReadySet means defining a read replica of your primary database. 
 Rails makes this incredibly simple and in the case of ReadySet, <b>you’ll configure the replica to point 
@@ -67,7 +54,7 @@ flags are set: `replica` is `true` and `database_tasks` is `false`. The `databas
 will disable Rails database migrations running against ReadySet. This isn’t needed as 
 ReadySet will see any changes to the primary database already. 
 
-### Update `ApplicationRecord` to use two connections
+### b. Update `ApplicationRecord` to use two connections
 
 In your application's `app/models` directory, you’ll find a base class for all of your model classes 
 often called `ApplicationRecord`. Open up that class and add the following line: 
@@ -93,7 +80,7 @@ If you aren't on Rails 7, you'll need to replace `primary_abstract_class` with `
 What's more, if for some reason you do not have access to an `ApplicationRecord` base class, you'll need to
 [monkey patch](https://dev.to/ayushn21/applying-monkey-patches-in-rails-1bj1) one. 
 
-### Activate connection switching middleware
+### c. Activate connection switching middleware
 
 Finally, you’ll need to activate Rails middleware that’ll ensure writes go to the primary database and 
 reads through ReadySet. First run this command to generate a configuration file: 
@@ -119,5 +106,5 @@ is consistent with writes that are going directly to the primary database.
 ## You’re off to the races! 
 
 At this point, if you start your Rails application, read requests will go directly to ReadySet and 
-writes will go to your primary Postgres database. You’ll next need to [configure which SQL select statements (i.e. reads) you’ll 
-want to cache](/get-started/cache/creating-a-cache). 
+writes will go to your primary Postgres database. You’ll next need to configure which SQL select statements (i.e. reads) you’ll 
+want to cache. Check out [our caching guide](/get-started/cache/creating-a-cache) for more information. 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -15,7 +15,7 @@ Setting up your application to take advantage of ReadySet takes a few steps.
 
 ## 1. Configuring Rails in 3 steps
 
-[Ruby On Rails allows you to configure ReadySet(https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
+[Ruby On Rails allows you to configure ReadySet](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching) as a read replica and define a time window after writes 
 for when to switch read traffic over to ReadySet. This allows clients to observe recent writes if there is write 
 traffic ongoing while still taking advantage of ReadySet's caching for read-heavy workloads.
 

--- a/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
+++ b/pages/get-started/connect/connect-an-application-via-an-orm/ruby-on-rails-with-readyset.mdx
@@ -9,16 +9,16 @@ In short, ReadySet becomes a lighting fast read-replica.
 
 ## Setting up ReadySet
 ReadySet can speed up Rails read queries quite easily. Setting up your application to take advantage of ReadySet takes a few steps. 
-First, connect ReadySet to your database. For instance, if [running with Docker](/get-started/install-rs) and connecting to Postgres, update the 
-`UPSTREAM_DB_URL` variable in ReadySet’s `compose.yml` to point to your Postgres instance. For instance, use the standard Postgres connection 
+First, connect ReadySet to your database. For instance, if [running with Docker](/get-started/install-rs) and connecting to Postgres, ensure the 
+`UPSTREAM_DB_URL` environment variable is pointing to your Postgres instance. For instance, use the standard Postgres connection 
 string in the format `postgresql://user:password@hostl:5432/database_name`. 
 
-Next, take note of the `LISTEN_ADDRESS` for your 
-ReadySet instance - normally this is set to `0.0.0.0:5433`. This will be important because this will become the address of the read replica you'll 
-add to your Rails application. 
+Next, take note of the host address for your ReadySet instance. This will be important because this will become the address of the 
+read replica you'll add to your Rails application. By default, ReadySet listens on port 5433. 
 
-To ensure [ReadySet is properly configured](/get-started/cache/check-snapshotting) and pointing to your target database, simply use the Postgres client, `psql` and connect to ReadySet as 
-you would a normal Postgres instance. You can do so by using the normal Postgres connection string and substitute in the port ReadySet is listening on (i.e. 5433). 
+To ensure [ReadySet is properly configured](/get-started/cache/check-snapshotting) and pointing to your target database, simply use 
+the Postgres client, `psql` and connect to ReadySet as you would a normal Postgres instance. You can do so by using the normal Postgres 
+connection string and substitute in the port ReadySet is listening on (i.e. 5433). 
 
 ```sh
 psql postgresql://user:password@host:5433/database_name

--- a/pages/get-started/install-rs/mysql.mdx
+++ b/pages/get-started/install-rs/mysql.mdx
@@ -52,11 +52,11 @@ If you'd like to import all of the tables in a given schema, you can specify tha
 Now, you're ready to start ReadySet. In your terminal, run the following command:  
 
 ```sh copy
-docker run -d -t -i  \
--p 5433:5433 \
+docker run -d -t -i                             \
+-p 5433:5433                                    \
 -e UPSTREAM_DB_URL=<database connection string> \
--e REPLICATION_TABLES=<your tables> \
--e LISTEN_ADDRESS=0.0.0.0:5433 \
+-e REPLICATION_TABLES=<your tables>             \
+-e LISTEN_ADDRESS=0.0.0.0:5433                  \
 readysettech/readyset:latest --standalone
 ```
 
@@ -67,10 +67,10 @@ For instance, connecting to a locally running docker Postgres and importing all 
 in the `locution` database would look like this:
 
 ```sh 
-docker run -d -t -t \
--p 5433:5433 \
+docker run -d -t -t                                                                \
+-p 5433:5433                                                                       \
 -e UPSTREAM_DB_URL=postgres://postgres:locution@host.docker.internal:5432/locution \
--e LISTEN_ADDRESS=0.0.0.0:5433 \
+-e LISTEN_ADDRESS=0.0.0.0:5433                                                     \
 readysettech/readyset:latest --standalone
 ```
 

--- a/pages/get-started/install-rs/mysql.mdx
+++ b/pages/get-started/install-rs/mysql.mdx
@@ -53,7 +53,7 @@ Now, you're ready to start ReadySet. In your terminal, run the following command
 
 ```sh copy
 docker run -d -t -i  \
--p 5433:5433 \ 
+-p 5433:5433 \
 -e UPSTREAM_DB_URL=<database connection string> \
 -e REPLICATION_TABLES=<your tables> \
 -e LISTEN_ADDRESS=0.0.0.0:5433 \
@@ -68,7 +68,7 @@ in the `locution` database would look like this:
 
 ```sh 
 docker run -d -t -t \
--p 5433:5433 \ 
+-p 5433:5433 \
 -e UPSTREAM_DB_URL=postgres://postgres:locution@host.docker.internal:5432/locution \
 -e LISTEN_ADDRESS=0.0.0.0:5433 \
 readysettech/readyset:latest --standalone

--- a/pages/get-started/install-rs/postgres.mdx
+++ b/pages/get-started/install-rs/postgres.mdx
@@ -54,11 +54,11 @@ If you'd like to import all database tables, you can skip passing in this argume
 Now, you're ready to start ReadySet. In your terminal, run the following command:  
 
 ```sh copy
-docker run -d -t -i  \
--p 5433:5433 \
+docker run -d -t -i                             \
+-p 5433:5433                                    \
 -e UPSTREAM_DB_URL=<database connection string> \
--e REPLICATION_TABLES=<your tables> \
--e LISTEN_ADDRESS=0.0.0.0:5433 \
+-e REPLICATION_TABLES=<your tables>             \
+-e LISTEN_ADDRESS=0.0.0.0:5433                  \
 readysettech/readyset:latest --standalone
 ```
 
@@ -68,10 +68,10 @@ For instance, connecting to a locally running docker Postgres and importing all 
 in the `locution` database would look like this:
 
 ```sh
-docker run -d -t -t \
--p 5433:5433 \
+docker run -d -t -t                                                                \
+-p 5433:5433                                                                       \
 -e UPSTREAM_DB_URL=postgres://postgres:locution@host.docker.internal:5432/locution \
--e LISTEN_ADDRESS=0.0.0.0:5433 \
+-e LISTEN_ADDRESS=0.0.0.0:5433                                                     \
 readysettech/readyset:latest --standalone
 ```
 

--- a/pages/get-started/install-rs/postgres.mdx
+++ b/pages/get-started/install-rs/postgres.mdx
@@ -55,7 +55,7 @@ Now, you're ready to start ReadySet. In your terminal, run the following command
 
 ```sh copy
 docker run -d -t -i  \
--p 5433:5433 \ 
+-p 5433:5433 \
 -e UPSTREAM_DB_URL=<database connection string> \
 -e REPLICATION_TABLES=<your tables> \
 -e LISTEN_ADDRESS=0.0.0.0:5433 \
@@ -69,7 +69,7 @@ in the `locution` database would look like this:
 
 ```sh
 docker run -d -t -t \
--p 5433:5433 \ 
+-p 5433:5433 \
 -e UPSTREAM_DB_URL=postgres://postgres:locution@host.docker.internal:5432/locution \
 -e LISTEN_ADDRESS=0.0.0.0:5433 \
 readysettech/readyset:latest --standalone


### PR DESCRIPTION
Old docs referenced `compose.xml` which is now obsolete. 