### PR TITLE
Typo in creating-a-cache.mdx

### DIFF
--- a/pages/get-started/cache/creating-a-cache.mdx
+++ b/pages/get-started/cache/creating-a-cache.mdx
@@ -2,7 +2,7 @@ import { Callout } from 'nextra/components'
 
 # Creating a Cache 
 
-It's import to note that ReadySet sits between your application and your database. SQL traffic must pass through ReadySet so 
+It's important to note that ReadySet sits between your application and your database. SQL traffic must pass through ReadySet so 
 that it can cache desired queries. You can check to see that an application is successfully connected to ReadySet
 by using the ReadySet shell and running the commands `show proxied queries` (you should see queries) or `show connections` (you should see two connections - one 
 being you in the ReadySet shell and the other being your application). 


### PR DESCRIPTION
Typo `import` -> `important`