### PR TITLE
remove hidden content that is showing up in search results

### DIFF
--- a/pages/get-started/cache/profiling-queries/_meta.json
+++ b/pages/get-started/cache/profiling-queries/_meta.json
@@ -1,9 +1,4 @@
 {
-  "view-query-metrics-with-grafana-wip": {
-    "display": "hidden"
-  },
-  "view-query-metrics-with-the-databases-slow-query-log": "View query metrics with the database's slow query log",
-  "view-query-metrics-with-3rd-party-providers-wip": {
-    "display": "hidden"
-  }
+  "view-query-metrics-with-the-databases-slow-query-log": "View query metrics with the database's slow query log"
+
 }

--- a/pages/get-started/cache/profiling-queries/view-query-metrics-with-3rd-party-providers-wip.md
+++ b/pages/get-started/cache/profiling-queries/view-query-metrics-with-3rd-party-providers-wip.md
@@ -1,1 +1,0 @@
-If you already have performance monitoring in place, use that tooling to identify queries that can benefit from caching in ReadySet.

--- a/pages/get-started/cache/profiling-queries/view-query-metrics-with-grafana-wip.md
+++ b/pages/get-started/cache/profiling-queries/view-query-metrics-with-grafana-wip.md
@@ -1,2 +1,0 @@
-# View query metrics with Grafana (WIP)
-When deployed with Docker, you can view the metrics for all queries that are proxied through or served by ReadySet at [localhost:4000](https://localhost:4000/).


### PR DESCRIPTION
Seems like `hidden` content was limited to the caching aspect of our documentation. 