### PR TITLE
Remove docs for `DROP CACHE <query text>`

### DIFF
--- a/pages/demo.mdx
+++ b/pages/demo.mdx
@@ -203,10 +203,6 @@ Remove a cache:
 ```sql copy
 DROP CACHE <query id>;
 ```
-or
-```sql copy
-DROP CACHE <query text>;
-```
 </Tab>
 
 <Tab>
@@ -388,10 +384,6 @@ SHOW PROXIED QUERIES;
 Remove a cache:
 ```sql copy
 DROP CACHE <query id>;
-```
-or
-```sql copy
-DROP CACHE <query text>;
 ```
 </Tab>
 </Tabs>

--- a/pages/get-started/cache.mdx
+++ b/pages/get-started/cache.mdx
@@ -118,9 +118,9 @@ This command returns a virtual table with 2 columns:
 To remove a cache from ReadySet, use:
 
 ```sql copy 
-DROP CACHE <query>;
+DROP CACHE <id>;
 ```
-- `<query>` is the full text of the query or the unique identifier (i.e. `query id`) assigned to the query by ReadySet, as seen in output of `SHOW CACHES`.
+- `<id>` is either the name assigned to the query by the user or the ID assigned to the query by ReadySet, as seen in the output of `SHOW CACHES`.
 
 
 After removing a query from ReadySet, any instances of this query will be proxied to the upstream database.


### PR DESCRIPTION
We decided not to support `DROP CACHE <query text>` after all, since the gem no longer needs the command with its current design. This commit removes the docs for the command added in #108.