### PR TITLE
docs: Fix multiple MySQL instructions

### DIFF
--- a/pages/get-started/connect/connect-via-database-shell.mdx
+++ b/pages/get-started/connect/connect-via-database-shell.mdx
@@ -28,13 +28,13 @@ ReadySet is wire-compatible with MySQL, so you can use the `mysql` client to con
 ReadySet uses the same username, password and database name as your upstream database.  To connect, fill in those values and run:
 
 ```sh
-mysql 'mysql://<username>:<password>@<host>:<port>/<db_name>'
+mysql -h<HOST> -u<USER> -p<PASSWORD> -P<READYSET PORT> <DATABASE>
 ```
 
 Once connected, you can see the status of tables in ReadySet by running:
 
 ```sql
-testdb=> SHOW READYSET STATUS;
+mysql> SHOW READYSET STATUS;
 ```
 </Tab>
 </Tabs>

--- a/pages/get-started/install-rs/docker/mysql.mdx
+++ b/pages/get-started/install-rs/docker/mysql.mdx
@@ -49,16 +49,16 @@ like to import all of the tables in a given schema, you can specify everything a
 Now, you're ready to start ReadySet. In your terminal, run the following command:  
 
 ```sh copy
-docker run -d -p 5433:5433 -p 6034:6034         \
+docker run -d -p 3307:3307 -p 6034:6034         \
 --name readyset                                 \
 -e UPSTREAM_DB_URL=<database connection string> \
 -e REPLICATION_TABLES=<specific tables or omit> \
--e LISTEN_ADDRESS=0.0.0.0:5433                  \
+-e LISTEN_ADDRESS=0.0.0.0:3307                  \
 readysettech/readyset:latest
 ```
 
-As you can see above, ReadySet is exposing two ports: 5433 and 6034. The ReadySet 
-process will listen for query traffic on port 5433 and emits telemetry on port 6034 via 
+As you can see above, ReadySet is exposing two ports: 3307 and 6034. The ReadySet
+process will listen for query traffic on port 3307 and emits telemetry on port 6034 via
 a `/metrics` endpoint. All `-e` environment variables can be 
 placed into a file and referenced via Docker's `--env-file` flag if you'd rather simply your command 
 line experience.

--- a/pages/reference/configure-your-database/mysql/generic-db-directions.mdx
+++ b/pages/reference/configure-your-database/mysql/generic-db-directions.mdx
@@ -57,7 +57,7 @@ ReadySet uses below list of privileges:
 * [`REPLICATION SLAVE`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_replication-slave) - Readyset register itself as a replica for CDC (Change Data Capture). This enables Readyset to automatically keep cache entries up to date when data changes in your database.
 * [`SELECT`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_select) - Used to snapshot data withing replicated tables.
 
-<Callout type="info">Note: ReadySet proxies all traffic from application to database. You should also add the privileges your current application uses to function (eg. [`INSERT`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_insert), [`DELETE`],(https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_delete), [`UPDATE`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_update))</Callout>
+<Callout type="info">Note: ReadySet proxies all traffic from application to database. You should also add the privileges your current application uses to function (eg. [`INSERT`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_insert), [`DELETE`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_delete), [`UPDATE`](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_update))</Callout>
 
 
 Example:


### PR DESCRIPTION
 - connect-via-database-shell - Fix instructions on connecting via mysql client and proper shell output.
 - docker-mysql - Adjust port to be mysql like. port 5433 has not meaning for MySQL. Set it to 3307 (our default for MySQL).
 - generic-db-directions - Fix to DELETE command link.