### PR TITLE
Consider string normalized types as unsupported

### DIFF
--- a/pages/reference/features/queries.mdx
+++ b/pages/reference/features/queries.mdx
@@ -114,6 +114,13 @@ ReadySet supports the following components of the SQL expression language:
 
 ### Unsupported
 
+ReadySet does not yet support the following data types:
+- `JSON`
+- `JSONB`
+- `UUID`
+- `MACADDR`
+- `INET`
+
 ReadySet does not support any of the following components of the SQL expression language (this is not an exhaustive list):
 - Literals
     - `DATE` and `TIME` specifications for literals
@@ -257,15 +264,6 @@ ReadySet supports the following data types:
     - ReadySet will parse, but ignores the optional length field
 - `SERIAL`
 - `BIGSERIAL`
-
-ReadySet additionally has limited support for the following data types:
-- `JSON`
-- `JSONB`
-- `UUID`
-- `MACADDR`
-- `INET`
-
-All of the above data types will be snapshotted and replicated by ReadySet, but represented internally as normalized text strings, which may cause them to behave differently with respect to expressions or sorting than in MySQL or Postgres.
 
 ### Character sets
 ReadySet stores all strings internally as UTF-8. ReadySet does not support any other character encoding for strings (though you can use the `BYTEA` SQL type to store arbitrary binary data), nor does it support any alternative collations or comparison methods (for example, strings in ReadySet are always compared case-sensitively, and always sorted character-wise lexicographically).

--- a/pages/reference/features/supported-data-types.mdx
+++ b/pages/reference/features/supported-data-types.mdx
@@ -58,10 +58,10 @@ The scope of data types, character sets, and table changes supported by ReadySet
 **Network address typess**
 | Type | Supported | Notes |
 | ---- | ---- | ---- |
-| [`INET`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-INET)| ✔️ |ReadySet represents this type internally as normalized string.|
+| [`INET`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-INET)| ✖️ | |
 | [`CIDR`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-CIDR)| ✖️ | |
-| [`MACADDR	`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR)| ✔️ |ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting.|
-| [`MACADDR8`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR8)| ✖️| |
+| [`MACADDR	`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR)| ✖️ | |
+| [`MACADDR8`](https://www.postgresql.org/docs/current/datatype-net-types.html#DATATYPE-MACADDR8)| ✖️ | |
 	
 **Bit string types**
 | Type | Supported | Notes |
@@ -77,7 +77,7 @@ The scope of data types, character sets, and table changes supported by ReadySet
 **UUID types**
 | Type | Supported | Notes |
 | ---- | ---- | ---- |
-| [`UUID`](https://www.postgresql.org/docs/current/datatype-uuid.html)| ✔️ |ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting.|
+| [`UUID`](https://www.postgresql.org/docs/current/datatype-uuid.html)|✖️ | |
 
 **XML types**
 | Type | Supported | Notes |
@@ -87,7 +87,7 @@ The scope of data types, character sets, and table changes supported by ReadySet
 **JSON types**
 | Type | Supported | Notes |
 | ---- | ---- | ---- |
-| [`JSON JSONB`](https://www.postgresql.org/docs/current/datatype-json.html)| ✔️ |ReadySet represents this type internally as a normalized string. This can cause different behavior than in Postgres with respect to expressions or sorting.|
+| [`JSON JSONB`](https://www.postgresql.org/docs/current/datatype-json.html)| ✖️ | |
 		
 **Array types**
 | Type | Supported | Notes |
@@ -144,7 +144,7 @@ The scope of data types, character sets, and table changes supported by ReadySet
 **JSON types**
 | Type | Supported | Notes |
 | ---- | ---- | ---- |
-| [`JSON`](https://dev.mysql.com/doc/refman/8.0/en/json.html)| ✔️ |ReadySet represents this type internally as a normalized string. This can cause different behavior than in MySQL with respect to expressions or sorting.|
+| [`JSON`](https://dev.mysql.com/doc/refman/8.0/en/json.html)| ✖️ | |
 
 **Spatial types**
 | Type | Supported | Notes |


### PR DESCRIPTION
Rather than documenting these types as "limited support" with caveats and allowing users to create caches with them and observe what they will most likely interpret as incorrect results, consider them to be unsupported until we can fully test their behavior and reason about/document specific differences with the upstream.