### PR TITLE
Docker: Add link to mysql database configuration

### DIFF
--- a/pages/get-started/install-rs/docker/mysql.mdx
+++ b/pages/get-started/install-rs/docker/mysql.mdx
@@ -1,37 +1,37 @@
 import { Callout } from 'nextra/components'
 
-# ReadySet Installation Guide for MySQL 
+# Readyset Installation Guide for MySQL 
 
-This guide walks you through how to run ReadySet using Docker, connecting to an existing primary database.
+This guide walks you through how to run Readyset using Docker, connecting to an existing primary database.
 
 ## 0. Make sure you can connect to your primary database.  
+Ensure your database and user are configured for Readyset to operate by following the [database reference documentation](http://localhost:3000/reference/configure-your-database/mysql/generic-db-directions).
 
-ReadySet needs to be installed on a machine that can communicate with your primary database. To check to make sure that it can, 
+Readyset needs to be installed on a machine that can communicate with your primary database. To check to make sure that it can, 
 you can run the following on that instance:
 
 ```sh copy
 mysql -u <username> -p -h <database host>
 ```
+If you are able to successfully make the connection, you are ready to move onto the next steps.
 
-If you are able to successfully make the connection, you are ready to move onto the next steps. 
-
-## 1. Ensure you have sufficient disk space and memory for ReadySet
-Any tables referenced by queries that you would like to cache need to be pulled into ReadySet. Before installing ReadySet, 
+## 1. Ensure you have sufficient disk space and memory for Readyset
+Any tables referenced by queries that you would like to cache need to be pulled into Readyset. Before installing Readyset, 
 ensure that the machine that you are installing it on has sufficient disk space and memory to replicate the base tables and 
 cache queries. 
 
 
-<Callout type="info"> Note that by default, ReadySet will pull in all tables from your database. If you only want to pull in specific
+<Callout type="info"> Note that by default, Readyset will pull in all tables from your database. If you only want to pull in specific
 tables, you will need to set the `--replication-tables` flag in Step 3.  </Callout>
 
-## 2. Download the ReadySet Docker image 
-To download the ReadySet Docker image from DockerHub, run the following command in your terminal:
+## 2. Download the Readyset Docker image 
+To download the Readyset Docker image from DockerHub, run the following command in your terminal:
 
 ```sh copy
 docker pull readysettech/readyset
 ```
 
-## 3. Run ReadySet
+## 3. Run Readyset
 
 First, find your primary database's connection string. 
 
@@ -39,14 +39,14 @@ It should look something like this:
 
 ```mysql://<username>:<password>@<host>:<port>/<db_name>```
 
-**By default, ReadySet will import all tables.** If you'd like to import all database tables, 
+**By default, Readyset will import all tables.** If you'd like to import all database tables, 
 you can skip defining a `REPLICATION_TABLES` environment variable. If, however, you'd only like
 to import a a subset of your database, then you need to define the list of tables you want to pull 
-into ReadySet as a comma-separated list: ```<schema>.<table>, <schema>.<table2>```. 
+into Readyset as a comma-separated list: ```<schema>.<table>, <schema>.<table2>```. 
 Note, this is optional - you can import all tables too by ignoring this command line flag. If you'd 
 like to import all of the tables in a given schema, you can specify everything as follows: ```<schema name>.*```. 
 
-Now, you're ready to start ReadySet. In your terminal, run the following command:  
+Now, you're ready to start Readyset. In your terminal, run the following command:  
 
 ```sh copy
 docker run -d -p 3307:3307 -p 6034:6034         \
@@ -57,7 +57,7 @@ docker run -d -p 3307:3307 -p 6034:6034         \
 readysettech/readyset:latest
 ```
 
-As you can see above, ReadySet is exposing two ports: 3307 and 6034. The ReadySet
+As you can see above, Readyset is exposing two ports: 3307 and 6034. The Readyset
 process will listen for query traffic on port 3307 and emits telemetry on port 6034 via
 a `/metrics` endpoint. All `-e` environment variables can be 
 placed into a file and referenced via Docker's `--env-file` flag if you'd rather simply your command 
@@ -72,8 +72,8 @@ not match the detected host platform (linux/arm64/v8) and no specific platform w
 can ignore this; alternatively, you can pass the `--platform linux/amd64` flag to the docker 
 `run` command to suppress the warning.  </Callout>
 
-ReadySet will then connect to your database and replicate specified tables (i.e. all or the explictly defined ones). 
-Depending on how large these tables are and the network connection between ReadySet and your database, 
+Readyset will then connect to your database and replicate specified tables (i.e. all or the explictly defined ones). 
+Depending on how large these tables are and the network connection between Readyset and your database, 
 this could take between seconds and hours. 
 
 To check whether the tables have been imported, run the following: 
@@ -90,9 +90,9 @@ Once you see:
 INFO replicators::noria_adapter: Streaming replication started
 ```
 
-ReadySet is ready to start caching queries.
+Readyset is ready to start caching queries.
 
-Alternatively, you can log into the ReadySet shell and run
+Alternatively, you can log into the Readyset shell and run
 
 ```sql
 SHOW READYSET STATUS;
@@ -100,8 +100,8 @@ SHOW READYSET STATUS;
 Look at the `Snapshot Status` column. If snapshotthing successfully completed, 
 it'll report `Completed`.
 
-Now ReadySet is ready to start caching queries.
+Now Readyset is ready to start caching queries.
 
 ## Next Steps
 
-As a next step, you can [connect to ReadySet from a database shell ](/get-started/connect/connect-via-database-shell) or [connect from your application](/get-started/connect/connect-an-application-via-an-orm). 
+As a next step, you can [connect to Readyset from a database shell ](/get-started/connect/connect-via-database-shell) or [connect from your application](/get-started/connect/connect-an-application-via-an-orm). 


### PR DESCRIPTION
Add a link to the mysql database configuration page in the docker installation guide. This make it more natural for people following the installation guide to find the required database configuration.

Adjusted ReadySet to Readyset